### PR TITLE
feat: add revert in safeMint()

### DIFF
--- a/packages/contracts/contracts/AuditBook.sol
+++ b/packages/contracts/contracts/AuditBook.sol
@@ -26,10 +26,11 @@ contract AuditBook is ERC721, Ownable {
     }
 
     function safeMint(address to) external {
-        IERC20(chai).safeTransferFrom(msg.sender, address(this), price);
+        if (balanceOf(to) > 0) revert("Already has an AuditBook");
         uint256 tokenId = _tokenIdCounter.current();
         _tokenIdCounter.increment();
         _safeMint(to, tokenId);
+        IERC20(chai).safeTransferFrom(msg.sender, address(this), price);
     }
 
     function tokenURI(uint tokenId) public view virtual override returns (string memory) {

--- a/packages/contracts/test/AuditBook.js
+++ b/packages/contracts/test/AuditBook.js
@@ -11,7 +11,7 @@ describe('AuditBookNFT', function () {
         const [owner, otherAccount] = await ethers.getSigners();
 
         const TestERC20 = await hre.ethers.getContractFactory('TestERC20');
-        const testERC20 = await TestERC20.deploy(BigNumber.from(10).pow(20));
+        const testERC20 = await TestERC20.deploy(BigNumber.from(10).pow(21));
 
         const AuditBook = await hre.ethers.getContractFactory('AuditBook');
         const auditBook = await AuditBook.deploy(
@@ -54,6 +54,22 @@ describe('AuditBookNFT', function () {
             await expect(
                 auditBook.connect(otherAccount).safeMint(otherAccount.address)
             ).to.be.reverted;
+        });
+        it('Should fail on the second mint to same address', async function () {
+            const { auditBook, testERC20, owner, otherAccount } =
+                await loadFixture(deployAuditBookFixture);
+            await expect(
+                testERC20.approve(auditBook.address, BigNumber.from(10).pow(18))
+            ).not.to.be.reverted;
+            await expect(auditBook.safeMint(otherAccount.address)).not.to.be
+                .reverted;
+
+            await expect(
+                testERC20.approve(auditBook.address, BigNumber.from(10).pow(18))
+            ).not.to.be.reverted;
+            await expect(
+                auditBook.safeMint(otherAccount.address)
+            ).to.be.revertedWith('Already has an AuditBook');
         });
     });
 


### PR DESCRIPTION
コントラクト内の `safeMint()` に、既にNFTを持っている人に対してオーナーが2つ目をミントできないように
```solidity
if (balanceOf(to) > 0) revert("Already has an AuditBook");
```
を追記してみました！

管理者のためだけの機能なので、不必要だったり問題があれば、Closeしていただければと:pray: