### PR TITLE
remove cname

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,4 +26,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./packages/book/docs
           enable_jekyll: true
-          cname: audit-book.unchain.tech


### PR DESCRIPTION
- bookのdeploymentのCNAMEレコードを外す (interfaceの方に `audit-book.unchain.tech` をアサインする)